### PR TITLE
feat(ci): add packaging scripts

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,56 @@
+name: Build Packages
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --locked
+      - name: Build Windows packages
+        shell: pwsh
+        run: ./scripts/package_windows.ps1
+
+  macos:
+    runs-on: macos-latest
+    env:
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --locked
+      - name: Build macOS package
+        run: ./scripts/package_macos.sh
+
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libayatana-appindicator3-dev
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --locked
+      - name: Build AppImage
+        run: ./scripts/package_linux.sh

--- a/scripts/package_linux.sh
+++ b/scripts/package_linux.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../apps/exrtool-gui/src-tauri"
+
+cargo tauri build --bundles appimage

--- a/scripts/package_macos.sh
+++ b/scripts/package_macos.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../apps/exrtool-gui/src-tauri"
+
+cargo tauri build --bundles dmg
+
+DMG="$(find ../target/release/bundle/dmg -name '*.dmg' | head -n 1 || true)"
+if [[ -n "${APPLE_ID:-}" && -n "${APPLE_PASSWORD:-}" && -n "${APPLE_TEAM_ID:-}" && -n "$DMG" ]]; then
+  xcrun notarytool submit "$DMG" --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
+  xcrun stapler staple "$DMG"
+else
+  echo "Skipping notarization, missing APPLE_ID/APPLE_PASSWORD/APPLE_TEAM_ID or dmg" >&2
+fi

--- a/scripts/package_windows.ps1
+++ b/scripts/package_windows.ps1
@@ -1,0 +1,16 @@
+[CmdletBinding()]
+param(
+    [string]$Bundles = "msix,msi"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$projectRoot = Join-Path $PSScriptRoot "..\apps\exrtool-gui\src-tauri"
+Set-Location $projectRoot
+
+if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+    Write-Error "cargo is not installed"
+}
+
+cargo tauri build --bundles $Bundles


### PR DESCRIPTION
## Summary
- add scripts to build Windows MSI/MSIX, macOS notarized DMG, and Linux AppImage
- wire new scripts into GitHub Actions workflow

## Testing
- `bash -n scripts/package_macos.sh scripts/package_linux.sh`
- `python3 - <<'PY'\nimport yaml,sys,pathlib\ntry:\n    yaml.safe_load(pathlib.Path('.github/workflows/package.yml').read_text())\n    print('YAML OK')\nexcept yaml.YAMLError as e:\n    print('YAML error:', e)\n    sys.exit(1)\nPY`
- `sudo apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_b_68c42934f5948328bebdf754ab63b9c9