### PR TITLE
feat(gui): enable in-memory LUT by default

### DIFF
--- a/apps/exrtool-gui/web/index.html
+++ b/apps/exrtool-gui/web/index.html
@@ -16,7 +16,7 @@
         <label>Max <input id="max" type="number" value="2048"/></label>
         <label>Exp <input id="exp" type="range" min="-8" max="8" step="0.1" value="0"/></label>
         <label>Gamma <input id="gamma" type="range" min="0.1" max="3.0" step="0.1" value="2.2"/></label>
-        <label><input id="use-state-lut" type="checkbox"/> Use LUT(in-memory)</label>
+        <label><input id="use-state-lut" type="checkbox" checked/> Use LUT(in-memory)</label>
         <button id="open">開く</button>
         <button id="save">PNG書き出し</button>
         <button id="showlog">ログ表示</button>

--- a/apps/exrtool-gui/web/index.js
+++ b/apps/exrtool-gui/web/index.js
@@ -1,6 +1,7 @@
 (() => {
   let invoke = null; // 解決済みの invoke（nullなら未解決）
   let imgW = 0, imgH = 0;
+  let useStateLutEnabled = false; // LUT in-memory 使用フラグ
 
   function getEl(id) {
     const el = document.getElementById(id);
@@ -45,7 +46,7 @@
     const ctx = cv.getContext('2d');
 
     const path = pathEl.value.trim();
-    const lutPath = lutEl ? (lutEl.value.trim() || null) : null;
+    const lutPath = (!useStateLutEnabled && lutEl) ? (lutEl.value.trim() || null) : null;
     try {
       if (!(await ensureTauriReady())) throw new Error('Tauri API が利用できません');
       const [w, h, b64] = await invoke('open_exr', {
@@ -86,6 +87,8 @@
     const applyPresetBtn = getEl('apply-preset');
     const clearLutBtn = getEl('clear-lut');
     const useStateLut = getEl('use-state-lut');
+
+    useStateLutEnabled = !!useStateLut?.checked;
 
     if (openBtn) openBtn.addEventListener('click', openExr);
 
@@ -140,8 +143,8 @@
             maxSize: parseInt(maxEl?.value ?? '2048',10) || 2048,
             exposure: parseFloat(expEl?.value ?? '0'),
             gamma: parseFloat(gammaEl?.value ?? '2.2'),
-            lutPath: (lutEl && lutEl.value.trim() && !(useStateLut?.checked)) ? lutEl.value.trim() : null,
-            useStateLut: !!(useStateLut?.checked),
+            lutPath: (lutEl && lutEl.value.trim() && !useStateLutEnabled) ? lutEl.value.trim() : null,
+            useStateLut: useStateLutEnabled,
           });
           const img = new Image();
           const info = getEl('info');
@@ -158,7 +161,10 @@
     };
     if (expEl) expEl.addEventListener('input', scheduleUpdate);
     if (gammaEl) gammaEl.addEventListener('input', scheduleUpdate);
-    if (useStateLut) useStateLut.addEventListener('change', scheduleUpdate);
+    if (useStateLut) useStateLut.addEventListener('change', () => {
+      useStateLutEnabled = !!useStateLut.checked;
+      scheduleUpdate();
+    });
 
     if (makeLutBtn) makeLutBtn.addEventListener('click', async () => {
       try {
@@ -193,13 +199,14 @@
           await invoke('set_lut_3d', { srcSpace: src, srcTf: 'linear', dstSpace: dst, dstTf: 'srgb', size: Math.max(17, Math.min(65, size)) });
         }
         if (useStateLut) useStateLut.checked = true;
+        useStateLutEnabled = true;
         scheduleUpdate();
         appendLog('Preset適用: ' + src + ' -> ' + dst);
       } catch (e) { appendLog('Preset適用失敗: ' + e); }
     });
 
     if (clearLutBtn) clearLutBtn.addEventListener('click', async () => {
-      try { if (!(await ensureTauriReady())) return; await invoke('clear_lut'); if (useStateLut) useStateLut.checked = false; scheduleUpdate(); appendLog('LUT解除'); } catch (e) { appendLog('解除失敗: ' + e); }
+      try { if (!(await ensureTauriReady())) return; await invoke('clear_lut'); if (useStateLut) useStateLut.checked = false; useStateLutEnabled = false; scheduleUpdate(); appendLog('LUT解除'); } catch (e) { appendLog('解除失敗: ' + e); }
     });
 
     // 早期にTauri注入が完了するケース向け


### PR DESCRIPTION
## Summary
- default the "Use LUT(in-memory)" checkbox to checked
- read checkbox state on load and propagate in-memory LUT flag

## Testing
- `cargo build -p exrtool-cli`
- `cd apps/exrtool-gui/src-tauri && cargo build` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c4290f83ac8328b2c9920a38adcd37