### PR TITLE
fix(gui): improve preview error reporting

### DIFF
--- a/apps/exrtool-gui/src-tauri/src/main.rs
+++ b/apps/exrtool-gui/src-tauri/src/main.rs
@@ -104,15 +104,30 @@ fn update_preview(
     } else { None };
 
     let mut s = state.lock();
-    let img = match s.image.as_ref() { Some(img) => img, None => return Err("image not loaded".into()) };
+    let img = match s.image.as_ref() {
+        Some(img) => img,
+        None => {
+            let msg = "update_preview: image not loaded; call open_exr first";
+            log_append(msg);
+            return Err(msg.into());
+        }
+    };
     let lut_ref = if use_state_lut { s.lut.as_ref() } else { lut_from_file.as_ref() };
     let preview = generate_preview(img, max_size, exposure, gamma, lut_ref);
     let png = image::RgbaImage::from_raw(preview.width, preview.height, preview.rgba8.clone())
-        .ok_or_else(|| "invalid image".to_string())?;
+        .ok_or_else(|| {
+            let msg = "update_preview: invalid preview buffer";
+            log_append(msg);
+            msg.to_string()
+        })?;
     let mut buf: Vec<u8> = Vec::new();
     image::DynamicImage::ImageRgba8(png)
         .write_to(&mut std::io::Cursor::new(&mut buf), image::ImageOutputFormat::Png)
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| {
+            let msg = format!("update_preview: encode failed: {}", e);
+            log_append(&msg);
+            msg
+        })?;
     let b64 = BASE64.encode(&buf);
 
     s.scale = (img.width as f32 / preview.width as f32)

--- a/apps/exrtool-gui/web/index.js
+++ b/apps/exrtool-gui/web/index.js
@@ -19,6 +19,17 @@
     console.log(line);
   }
 
+  function showError(msg) {
+    let el = document.getElementById('errordiv');
+    if (!el) {
+      el = document.createElement('div');
+      el.id = 'errordiv';
+      el.style.color = 'red';
+      document.body.appendChild(el);
+    }
+    el.textContent = msg;
+  }
+
   async function ensureTauriReady(timeoutMs = 5000) {
     const start = Date.now();
     while (Date.now() - start < timeoutMs) {
@@ -153,7 +164,11 @@
             if (info) info.textContent = `preview: ${w}x${h}`;
           };
           img.src = 'data:image/png;base64,' + b64;
-        } catch (e) { appendLog('update失敗: ' + e); }
+          showError('');
+        } catch (e) {
+          appendLog('update失敗: ' + e);
+          showError('update失敗: ' + e);
+        }
       }, 120);
     };
     if (expEl) expEl.addEventListener('input', scheduleUpdate);


### PR DESCRIPTION
## Summary
- add detailed context when `update_preview` fails in Tauri backend
- surface `update_preview` errors in the web UI with red text

## Testing
- `cargo build -p exrtool-cli`
- `cargo build` *(apps/exrtool-gui/src-tauri; missing `javascriptcoregtk-4.0`)*

------
https://chatgpt.com/codex/tasks/task_b_68c42911074c8328a1dfaef26d194bde