### PR TITLE
feat(gui): add LUT presets selector

### DIFF
--- a/apps/exrtool-gui/web/index.html
+++ b/apps/exrtool-gui/web/index.html
@@ -26,6 +26,14 @@
         <label>Make LUT: 元<select id="lut-src"><option>linear</option><option>srgb</option><option>acescg</option><option>rec2020</option><option>aces2065</option></select></label>
         <label>→ 先<select id="lut-dst"><option>srgb</option><option>linear</option><option>acescg</option><option>rec2020</option><option>aces2065</option></select></label>
         <label>Size <input id="lut-size" type="number" value="33" min="17" max="65" step="1"/></label>
+        <label>Preset
+          <select id="lut-preset">
+            <option value="">-</option>
+            <option value="acescg-srgb" selected>ACEScg → sRGB</option>
+            <option value="aces2065-srgb">ACES2065-1 → sRGB</option>
+            <option value="srgb-acescg">sRGB → ACEScg</option>
+          </select>
+        </label>
         <button id="make-lut">LUT生成(.cube)</button>
         <button id="apply-preset">Preset適用(メモリ)</button>
         <button id="clear-lut">LUT解除</button>

--- a/apps/exrtool-gui/web/index.js
+++ b/apps/exrtool-gui/web/index.js
@@ -82,6 +82,7 @@
     const lutSrc = getEl('lut-src');
     const lutDst = getEl('lut-dst');
     const lutSize = getEl('lut-size');
+    const lutPreset = getEl('lut-preset');
     const makeLutBtn = getEl('make-lut');
     const applyPresetBtn = getEl('apply-preset');
     const clearLutBtn = getEl('clear-lut');
@@ -198,9 +199,31 @@
       } catch (e) { appendLog('Preset適用失敗: ' + e); }
     });
 
+    if (lutPreset) lutPreset.addEventListener('change', async () => {
+      const val = lutPreset.value;
+      if (!val) return;
+      const [src, dst] = val.split('-');
+      if (lutSrc) lutSrc.value = src;
+      if (lutDst) lutDst.value = dst;
+      try {
+        if (!(await ensureTauriReady())) return;
+        const size = parseInt(lutSize?.value ?? '33',10) || 33;
+        if (src === 'linear' || src === 'srgb') {
+          await invoke('set_lut_1d', { src, dst, size });
+        } else {
+          await invoke('set_lut_3d', { srcSpace: src, srcTf: 'linear', dstSpace: dst, dstTf: 'srgb', size: Math.max(17, Math.min(65, size)) });
+        }
+        if (useStateLut) useStateLut.checked = true;
+        scheduleUpdate();
+        appendLog('Preset適用: ' + src + ' -> ' + dst);
+      } catch (e) { appendLog('Preset適用失敗: ' + e); }
+    });
+
     if (clearLutBtn) clearLutBtn.addEventListener('click', async () => {
       try { if (!(await ensureTauriReady())) return; await invoke('clear_lut'); if (useStateLut) useStateLut.checked = false; scheduleUpdate(); appendLog('LUT解除'); } catch (e) { appendLog('解除失敗: ' + e); }
     });
+
+    if (lutPreset) lutPreset.dispatchEvent(new Event('change'));
 
     // 早期にTauri注入が完了するケース向け
     ensureTauriReady(2000);


### PR DESCRIPTION
## Summary
- add preset dropdown to select common LUT conversions
- apply selected preset to LUT state and update preview

## Testing
- `cargo build -p exrtool-cli`
- `cd apps/exrtool-gui/src-tauri && cargo build` *(fails: javascriptcoregtk-4.0 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c42914133c8328b9ca5a7369e6bc4e