### PR TITLE
feat(gui): add async preview progress with cancel support

### DIFF
--- a/apps/exrtool-gui/src-tauri/src/main.rs
+++ b/apps/exrtool-gui/src-tauri/src/main.rs
@@ -6,11 +6,12 @@ use std::fs::OpenOptions;
 use std::io::Write as _;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
-use exrtool_core::{export_png, generate_preview, parse_cube, LoadedExr, PreviewImage, Lut};
+use exrtool_core::{export_png, parse_cube, generate_preview, apply_gamma, srgb_encode, LoadedExr, PreviewImage, Lut};
 
 struct AppState {
     image: Option<LoadedExr>,
@@ -25,9 +26,21 @@ impl Default for AppState {
     }
 }
 
+struct OpenProgress {
+    cancel: AtomicBool,
+}
+
+impl Default for OpenProgress {
+    fn default() -> Self {
+        Self { cancel: AtomicBool::new(false) }
+    }
+}
+
 #[tauri::command]
-fn open_exr(
+async fn open_exr(
+    window: tauri::Window,
     state: tauri::State<Arc<Mutex<AppState>>>,
+    prog: tauri::State<Arc<OpenProgress>>,
     path: String,
     max_size: u32,
     exposure: f32,
@@ -39,11 +52,7 @@ fn open_exr(
         "open_exr: path='{}' max={} exp={} gamma={} lut={:?}",
         path, max_size, exposure, gamma, lut_path
     ));
-    let img = exrtool_core::load_exr_basic(&pathbuf)
-        .map_err(|e| {
-            log_append(&format!("open_exr: load failed: {}", e));
-            e.to_string()
-        })?;
+
     if let Some(p) = lut_path {
         match std::fs::read_to_string(&p) {
             Ok(t) => match parse_cube(&t) {
@@ -54,19 +63,41 @@ fn open_exr(
         }
     }
 
+    prog.cancel.store(false, Ordering::SeqCst);
     let s_lut = state.lock().lut.clone();
-    let preview = generate_preview(&img, max_size, exposure, gamma, s_lut.as_ref());
-    let png = image::RgbaImage::from_raw(preview.width, preview.height, preview.rgba8.clone())
-        .ok_or_else(|| "invalid image".to_string())?;
-    let mut buf: Vec<u8> = Vec::new();
-    image::DynamicImage::ImageRgba8(png)
-        .write_to(&mut std::io::Cursor::new(&mut buf), image::ImageOutputFormat::Png)
-        .map_err(|e| e.to_string())?;
-    let b64 = BASE64.encode(&buf);
+    let prog2 = prog.clone();
+    let win = window.clone();
 
-    let scale = (img.width as f32 / preview.width as f32)
-        .max(img.height as f32 / preview.height as f32)
-        .max(1.0);
+    let task = tauri::async_runtime::spawn_blocking(move || {
+        let img = exrtool_core::load_exr_basic(&pathbuf)
+            .map_err(|e| {
+                log_append(&format!("open_exr: load failed: {}", e));
+                e.to_string()
+            })?;
+
+        if prog2.cancel.load(Ordering::SeqCst) {
+            return Err("cancelled".to_string());
+        }
+
+        let preview = generate_preview_progress(&img, max_size, exposure, gamma, s_lut.as_ref(), &win, &prog2)?;
+
+        let png = image::RgbaImage::from_raw(preview.width, preview.height, preview.rgba8.clone())
+            .ok_or_else(|| "invalid image".to_string())?;
+        let mut buf: Vec<u8> = Vec::new();
+        image::DynamicImage::ImageRgba8(png)
+            .write_to(&mut std::io::Cursor::new(&mut buf), image::ImageOutputFormat::Png)
+            .map_err(|e| e.to_string())?;
+        let b64 = BASE64.encode(&buf);
+
+        let scale = (img.width as f32 / preview.width as f32)
+            .max(img.height as f32 / preview.height as f32)
+            .max(1.0);
+
+        Ok((img, preview, scale, b64))
+    });
+
+    let (img, preview, scale, b64) = task.await.map_err(|e| e.to_string())??;
+
     let mut s = state.lock();
     s.image = Some(img);
     s.preview = Some(preview);
@@ -76,6 +107,8 @@ fn open_exr(
         s.preview.as_ref().unwrap().width,
         s.preview.as_ref().unwrap().height
     ));
+
+    window.emit("open-progress", 100.0).ok();
 
     Ok((
         s.preview.as_ref().unwrap().width,
@@ -182,6 +215,12 @@ fn clear_log() -> Result<(), String> {
     std::fs::write(log_path(), "").map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+fn cancel_open(prog: tauri::State<Arc<OpenProgress>>) -> Result<(), String> {
+    prog.cancel.store(true, Ordering::SeqCst);
+    Ok(())
+}
+
 fn log_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("exrtool-gui.log")
 }
@@ -199,6 +238,84 @@ fn log_append(msg: &str) {
     {
         let _ = f.write_all(line.as_bytes());
     }
+}
+
+fn generate_preview_progress(
+    img: &LoadedExr,
+    max_size: u32,
+    exposure: f32,
+    gamma: f32,
+    lut: Option<&Lut>,
+    window: &tauri::Window,
+    prog: &OpenProgress,
+) -> Result<PreviewImage, String> {
+    let (w, h) = (img.width as u32, img.height as u32);
+    let scale = if w <= max_size && h <= max_size {
+        1.0
+    } else {
+        (max_size as f32 / w as f32).min(max_size as f32 / h as f32)
+    };
+    let out_w = (w as f32 * scale).round().max(1.0) as u32;
+    let out_h = (h as f32 * scale).round().max(1.0) as u32;
+
+    let mut rgba8 = vec![0u8; (out_w * out_h * 4) as usize];
+    let _ = window.emit("open-progress", 0.0);
+
+    for oy in 0..out_h {
+        for ox in 0..out_w {
+            let sx = (ox as f32) / scale;
+            let sy = (oy as f32) / scale;
+            let x0 = sx.floor().clamp(0.0, (w - 1) as f32) as i32;
+            let y0 = sy.floor().clamp(0.0, (h - 1) as f32) as i32;
+            let x1 = (x0 + 1).min(w as i32 - 1);
+            let y1 = (y0 + 1).min(h as i32 - 1);
+            let tx = (sx - x0 as f32).clamp(0.0, 1.0);
+            let ty = (sy - y0 as f32).clamp(0.0, 1.0);
+
+            let sample = |x:i32,y:i32| -> (f32,f32,f32,f32) {
+                let idx = (y as usize * img.width + x as usize) * 4;
+                (
+                    img.rgba_f32[idx+0],
+                    img.rgba_f32[idx+1],
+                    img.rgba_f32[idx+2],
+                    img.rgba_f32[idx+3]
+                )
+            };
+            let (r00,g00,b00,a00) = sample(x0,y0);
+            let (r10,g10,b10,a10) = sample(x1,y0);
+            let (r01,g01,b01,a01) = sample(x0,y1);
+            let (r11,g11,b11,a11) = sample(x1,y1);
+            let lerp = |a:f32,b:f32,t:f32| a + (b-a)*t;
+            let r0 = lerp(r00,r10,tx); let r1 = lerp(r01,r11,tx); let mut r = lerp(r0,r1,ty);
+            let g0 = lerp(g00,g10,tx); let g1 = lerp(g01,g11,tx); let mut g = lerp(g0,g1,ty);
+            let b0 = lerp(b00,b10,tx); let b1 = lerp(b01,b11,tx); let mut b = lerp(b0,b1,ty);
+            let a0 = lerp(a00,a10,tx); let a1 = lerp(a01,a11,tx); let a = lerp(a0,a1,ty);
+
+            let m = 2.0f32.powf(exposure);
+            r *= m; g *= m; b *= m;
+
+            if let Some(l) = lut {
+                let rgb = l.apply([r, g, b]);
+                r = rgb[0]; g = rgb[1]; b = rgb[2];
+            }
+
+            let rgb = apply_gamma([r, g, b], gamma);
+            let (r8, g8, b8) = (srgb_encode(rgb[0]), srgb_encode(rgb[1]), srgb_encode(rgb[2]));
+
+            let di = (oy * out_w + ox) as usize * 4;
+            rgba8[di + 0] = r8;
+            rgba8[di + 1] = g8;
+            rgba8[di + 2] = b8;
+            rgba8[di + 3] = (a.clamp(0.0, 1.0) * 255.0).round() as u8;
+        }
+        let pct = ((oy + 1) as f64 / out_h as f64) * 100.0;
+        let _ = window.emit("open-progress", pct);
+        if prog.cancel.load(Ordering::SeqCst) {
+            return Err("cancelled".to_string());
+        }
+    }
+
+    Ok(PreviewImage { width: out_w, height: out_h, rgba8 })
 }
 
 #[tauri::command]
@@ -298,6 +415,7 @@ fn make_lut3d(src_space: String, src_tf: String, dst_space: String, dst_tf: Stri
 fn main() {
     tauri::Builder::default()
         .manage(Arc::new(Mutex::new(AppState::default())))
+        .manage(Arc::new(OpenProgress::default()))
         .invoke_handler(tauri::generate_handler![
             open_exr,
             update_preview,
@@ -305,6 +423,7 @@ fn main() {
             export_preview_png,
             read_log,
             clear_log,
+            cancel_open,
             set_lut_1d,
             set_lut_3d,
             clear_lut


### PR DESCRIPTION
## Summary
- add async EXR preview generation that emits progress events and supports cancellation
- display progress bar and cancel button in web UI using Tauri events

## Testing
- `node --check apps/exrtool-gui/web/index.js`
- `cargo build` *(fails: system library `javascriptcoregtk-4.0` missing)*


------
https://chatgpt.com/codex/tasks/task_b_68c4291f9d188328b2482059acdbc5f9