### PR TITLE
feat(core): enable metadata write-back

### DIFF
--- a/crates/exrtool-core/src/lib.rs
+++ b/crates/exrtool-core/src/lib.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use nalgebra::{Matrix3, Vector3};
 
+#[cfg(feature = "use_exr_crate")]
+pub mod metadata;
+#[cfg(feature = "use_exr_crate")]
+mod save;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PreviewImage {
     pub width: u32,

--- a/crates/exrtool-core/src/metadata.rs
+++ b/crates/exrtool-core/src/metadata.rs
@@ -1,0 +1,40 @@
+#[cfg(feature = "use_exr_crate")]
+use std::collections::HashMap;
+#[cfg(feature = "use_exr_crate")]
+use std::path::Path;
+
+#[cfg(feature = "use_exr_crate")]
+use anyhow::Result;
+#[cfg(feature = "use_exr_crate")]
+use exr::meta::attribute::{AttributeValue, Text};
+#[cfg(feature = "use_exr_crate")]
+use exr::prelude::*;
+
+#[cfg(feature = "use_exr_crate")]
+use crate::save::save_any_image;
+
+/// Write the provided metadata back to the EXR file.
+///
+/// If `out` is `Some`, the image is written to that path
+/// instead of overwriting the source file.
+#[cfg(feature = "use_exr_crate")]
+pub fn write_metadata(
+    src: &Path,
+    metadata: &HashMap<String, String>,
+    out: Option<&Path>,
+) -> Result<()> {
+    let mut image = read_all_data_from_file(src)?;
+
+    for (k, v) in metadata {
+        let key = Text::from(k.as_str());
+        let val = Text::from(v.as_str());
+        let attr = AttributeValue::Text(val.clone());
+        image.attributes.other.insert(key.clone(), attr.clone());
+        if let Some(layer) = image.layer_data.get_mut(0) {
+            layer.attributes.other.insert(key, attr);
+        }
+    }
+
+    let target = out.unwrap_or(src);
+    save_any_image(&image, target)
+}

--- a/crates/exrtool-core/src/save.rs
+++ b/crates/exrtool-core/src/save.rs
@@ -1,0 +1,16 @@
+#[cfg(feature = "use_exr_crate")]
+use anyhow::Result;
+#[cfg(feature = "use_exr_crate")]
+use exr::prelude::*;
+#[cfg(feature = "use_exr_crate")]
+use std::path::Path;
+
+/// Save an EXR image to the specified path.
+///
+/// This wrapper exists so the write mechanism can later
+/// be replaced with an atomic operation.
+#[cfg(feature = "use_exr_crate")]
+pub fn save_any_image(image: &AnyImage, path: &Path) -> Result<()> {
+    image.write().to_file(path)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `metadata::write_metadata` to write EXR attributes and optionally save under a new path
- wrap EXR file output in `save::save_any_image` for future atomic replace support

## Testing
- `cargo build -p exrtool-core --features use_exr_crate`
- `cargo build -p exrtool-cli`


------
https://chatgpt.com/codex/tasks/task_b_68c42927d5808328ba898717db92406c