### PR TITLE
ci: package artifacts and document signing

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Build Windows packages
         shell: pwsh
         run: ./scripts/package_windows.ps1
+      - uses: actions/upload-artifact@v3
+        with:
+          name: exrtool-windows
+          path: |
+            apps/exrtool-gui/src-tauri/target/release/bundle/msi/*.msi
+            apps/exrtool-gui/src-tauri/target/release/bundle/msix/*.msix
 
   macos:
     runs-on: macos-latest
@@ -37,6 +43,10 @@ jobs:
         run: cargo install tauri-cli --locked
       - name: Build macOS package
         run: ./scripts/package_macos.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: exrtool-macos
+          path: apps/exrtool-gui/src-tauri/target/release/bundle/dmg/*.dmg
 
   linux:
     runs-on: ubuntu-latest
@@ -54,3 +64,7 @@ jobs:
         run: cargo install tauri-cli --locked
       - name: Build AppImage
         run: ./scripts/package_linux.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: exrtool-linux
+          path: apps/exrtool-gui/src-tauri/target/release/bundle/appimage/*.AppImage

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -1,0 +1,34 @@
+# パッケージ署名・検証手順
+
+本プロジェクトで生成される各OS向けパッケージの署名および検証手順をまとめます。
+
+## Windows (MSIX/MSI)
+1. `signtool` で署名します。
+   ```powershell
+   signtool sign /fd SHA256 /a path\to\exrtool.msix
+   signtool sign /fd SHA256 /a path\to\exrtool.msi
+   ```
+2. 署名の検証。
+   ```powershell
+   signtool verify /pa path\to\exrtool.msix
+   signtool verify /pa path\to\exrtool.msi
+   ```
+
+## macOS (DMG notarize)
+1. `scripts/package_macos.sh` は `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID` が設定されている場合、
+   `xcrun notarytool` と `xcrun stapler` を使って自動で公証（notarize）を行います。
+2. 生成された DMG の検証。
+   ```bash
+   spctl -a -vv path/to/exrtool.dmg
+   ```
+   `source=Notarized Developer ID` と表示されれば成功です。
+
+## Linux (AppImage)
+1. GPG で署名を生成します。
+   ```bash
+   gpg --output exrtool.AppImage.sig --detach-sign exrtool.AppImage
+   ```
+2. 署名の検証。
+   ```bash
+   gpg --verify exrtool.AppImage.sig exrtool.AppImage
+   ```


### PR DESCRIPTION
## Summary
- upload platform packages (MSIX/MSI, notarized DMG, AppImage) in CI
- document package signing and verification for Windows, macOS, and Linux

## Testing
- `cargo build -p exrtool-cli`
- `cargo build` (GUI, fails: The system library `glib-2.0` required by crate `glib-sys` was not found)
- `.githooks/pre-commit`

------
https://chatgpt.com/codex/tasks/task_b_68c689793b5c832886bbb2132f20e8b8