### PR TITLE
feat(cli): add fps-set subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ cargo run -p exrtool-cli -- make-lut3d --src-space acescg --src-tf linear --dst-
 
 # ルールに基づく一括適用（PNG書出し）。dry-run/backup対応
 cargo run -p exrtool-cli -- apply --rules docs/rules.yml --dry-run false --backup true
+
+# 単一EXRのFPS属性を設定（FramesPerSecond, backupあり）
+cargo run -p exrtool-cli -- fps-set --input "C:\\path\\to\\frame.exr" --fps 24 --dry-run false --backup true
 ```
 
 ## Video Tools（GUI）


### PR DESCRIPTION
## Summary
- add `fps-set` CLI subcommand to write FramesPerSecond metadata
- document new command usage

## Testing
- `cargo test -p exrtool-cli`
- `cargo test -p exrtool-cli --features exr_pure`
- `cargo run -p exrtool-cli --features exr_pure -- fps-set --input dummy.exr --fps 30 --dry-run`


------
https://chatgpt.com/codex/tasks/task_b_68c6896212808328bded71b66a14701a