### PR TITLE
refactor(gui): merge video tools into preview

### DIFF
--- a/apps/exrtool-gui/web/index.html
+++ b/apps/exrtool-gui/web/index.html
@@ -16,7 +16,6 @@
   <body>
     <nav class="tabs">
       <button id="tab-btn-preview" class="active">Preview</button>
-      <button id="tab-btn-video">Video</button>
       <button id="tab-btn-settings">Settings</button>
     </nav>
     <section id="tab-preview" style="display:block;">
@@ -76,59 +75,58 @@
           </table>
         </div>
       </div>
-    </main>
-    </section>
-
-    <section id="tab-video" style="display:none; padding:8px 12px;">
-      <h2>Video Tools</h2>
-      <div class="toolbar">
-        <label>Sequence Folder: <input id="seq-dir" size="50" placeholder="Select EXR sequence folder"/></label>
-        <button id="browse-seq">Browse…</button>
-      </div>
-      <fieldset>
-        <legend>Set FPS (write metadata)</legend>
-        <label>FPS <input id="seq-fps" type="number" min="1" step="0.01" value="24"/></label>
-        <label>Attribute <input id="seq-fps-attr" type="text" value="FramesPerSecond"/></label>
-        <label><input id="seq-fps-recursive" type="checkbox"/> Recursive</label>
-        <label><input id="seq-fps-dryrun" type="checkbox"/> Dry Run</label>
-        <button id="apply-fps">Apply FPS</button>
-        <button id="cancel-fps" style="display:none;">Cancel</button>
-        <progress id="seq-progress" max="100" value="0" style="width: 100%; display:none;"></progress>
-        <small>Note: requires GUI build with feature exr_pure.</small>
-      </fieldset>
-      <fieldset>
-        <legend>Export ProRes</legend>
-        <label>FPS <input id="prores-fps" type="number" min="1" step="0.01" value="24"/></label>
-        <label>Colorspace
-          <select id="prores-colorspace">
-            <option value="linear:srgb" selected>Linear → sRGB</option>
-            <option value="acescg:srgb">ACEScg → sRGB</option>
-            <option value="aces2065:srgb">ACES2065-1 → sRGB</option>
-          </select>
-        </label>
-        <label>Profile
-          <select id="prores-profile">
-            <option value="422hq" selected>ProRes 422 HQ</option>
-            <option value="422">ProRes 422</option>
-            <option value="4444">ProRes 4444</option>
-          </select>
-        </label>
-        <label>Max Size <input id="prores-max" type="number" value="2048"/></label>
-        <!-- Exposure removed by request -->
-        <label>TF <select id="prores-tf"><option value="g22" selected>g22</option><option value="g24">g24</option><option value="linear">linear</option></select></label>
-        <label>Quality
-          <select id="prores-quality">
-            <option value="High" selected>High</option>
-            <option value="Fast">Fast</option>
-          </select>
-        </label>
-        <div style="margin-top:6px;">
-          <label>Output MOV: <input id="prores-out" size="40" placeholder="C:\\path\\to\\out.mov"/></label>
-          <button id="browse-prores-out">Browse…</button>
-          <button id="export-prores">Export ProRes</button>
+      <div id="video-tools">
+        <h2>Video Tools</h2>
+        <div class="toolbar">
+          <label>Sequence Folder: <input id="seq-dir" size="50" placeholder="Select EXR sequence folder"/></label>
+          <button id="browse-seq">Browse…</button>
         </div>
-        <progress id="prores-progress" max="100" value="0" style="width: 100%; display:none;"></progress>
-      </fieldset>
+        <fieldset>
+          <legend>Set FPS (write metadata)</legend>
+          <label>FPS <input id="seq-fps" type="number" min="1" step="0.01" value="24"/></label>
+          <label>Attribute <input id="seq-fps-attr" type="text" value="FramesPerSecond"/></label>
+          <label><input id="seq-fps-recursive" type="checkbox"/> Recursive</label>
+          <label><input id="seq-fps-dryrun" type="checkbox"/> Dry Run</label>
+          <button id="apply-fps">Apply FPS</button>
+          <button id="cancel-fps" style="display:none;">Cancel</button>
+          <progress id="seq-progress" max="100" value="0" style="width: 100%; display:none;"></progress>
+          <small>Note: requires GUI build with feature exr_pure.</small>
+        </fieldset>
+        <fieldset>
+          <legend>Export ProRes</legend>
+          <label>FPS <input id="prores-fps" type="number" min="1" step="0.01" value="24"/></label>
+          <label>Colorspace
+            <select id="prores-colorspace">
+              <option value="linear:srgb" selected>Linear → sRGB</option>
+              <option value="acescg:srgb">ACEScg → sRGB</option>
+              <option value="aces2065:srgb">ACES2065-1 → sRGB</option>
+            </select>
+          </label>
+          <label>Profile
+            <select id="prores-profile">
+              <option value="422hq" selected>ProRes 422 HQ</option>
+              <option value="422">ProRes 422</option>
+              <option value="4444">ProRes 4444</option>
+            </select>
+          </label>
+          <label>Max Size <input id="prores-max" type="number" value="2048"/></label>
+          <!-- Exposure removed by request -->
+          <label>TF <select id="prores-tf"><option value="g22" selected>g22</option><option value="g24">g24</option><option value="linear">linear</option></select></label>
+          <label>Quality
+            <select id="prores-quality">
+              <option value="High" selected>High</option>
+              <option value="Fast">Fast</option>
+            </select>
+          </label>
+          <div style="margin-top:6px;">
+            <label>Output MOV: <input id="prores-out" size="40" placeholder="C:\\path\\to\\out.mov"/></label>
+            <button id="browse-prores-out">Browse…</button>
+            <button id="export-prores">Export ProRes</button>
+          </div>
+          <progress id="prores-progress" max="100" value="0" style="width: 100%; display:none;"></progress>
+        </fieldset>
+      </div>
+    </main>
     </section>
 
     <section id="tab-settings" style="display:none; padding:8px 12px;">

--- a/apps/exrtool-gui/web/index.js
+++ b/apps/exrtool-gui/web/index.js
@@ -225,27 +225,20 @@
     }
   }
 
-  document.addEventListener('DOMContentLoaded', () => {
-    // Tabs
+  function initPreviewDom() {
     const tabBtnPreview = document.getElementById('tab-btn-preview');
-    const tabBtnVideo = document.getElementById('tab-btn-video');
     const tabBtnSettings = document.getElementById('tab-btn-settings');
     const tabPreview = document.getElementById('tab-preview');
-    const tabVideo = document.getElementById('tab-video');
     const tabSettings = document.getElementById('tab-settings');
     function activate(tab){
-      if (!tabPreview || !tabVideo || !tabSettings) return;
+      if (!tabPreview || !tabSettings) return;
       tabPreview.style.display = (tab === 'preview') ? 'block' : 'none';
-      tabVideo.style.display = (tab === 'video') ? 'block' : 'none';
       tabSettings.style.display = (tab === 'settings') ? 'block' : 'none';
       tabBtnPreview?.classList.toggle('active', tab === 'preview');
-      tabBtnVideo?.classList.toggle('active', tab === 'video');
       tabBtnSettings?.classList.toggle('active', tab === 'settings');
     }
     tabBtnPreview?.addEventListener('click', ()=>{ logBoth('tab: preview'); activate('preview'); });
-    tabBtnVideo?.addEventListener('click', ()=>{ logBoth('tab: video'); activate('video'); });
     tabBtnSettings?.addEventListener('click', ()=>{ logBoth('tab: settings'); activate('settings'); });
-    logBoth('boot: video controls present? browse-seq=' + (!!document.getElementById('browse-seq')) + ', browse-prores-out=' + (!!document.getElementById('browse-prores-out')));
     const openBtn = getEl('open');
     const browseBtn = getEl('browse');
     const saveBtn = getEl('save');
@@ -743,4 +736,7 @@
         }
       } catch (e) { appendLog('ProRes出力失敗: ' + e); alert('ProRes出力失敗: ' + e); }
     });
+  }
+
+  document.addEventListener('DOMContentLoaded', initPreviewDom);
 })();

--- a/apps/exrtool-gui/web/style.css
+++ b/apps/exrtool-gui/web/style.css
@@ -1,7 +1,7 @@
 html, body { height: 100%; margin: 0; font-family: system-ui, sans-serif; }
 header { padding: 8px; background: #20232a; color: #fff; }
 .toolbar { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
-main { display: grid; grid-template-columns: 1fr 300px; gap: 8px; padding: 8px; }
+main { display: grid; grid-template-columns: 1fr 300px 300px; gap: 8px; padding: 8px; }
 canvas { border: 1px solid #ccc; max-width: 100%; }
 .readout { font-family: ui-monospace, Menlo, Consolas, monospace; }
 .info { margin-top: 6px; font-size: 12px; opacity: 0.8; }


### PR DESCRIPTION
## Summary
- integrate Video tab controls into Preview tab
- simplify tab switching to Preview initializer
- expand CSS grid to three columns

## Testing
- `cargo build` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*

------
https://chatgpt.com/codex/tasks/task_b_68c6f07230308328a315c00979b78dce