### PR TITLE
feat(gui): add playback timeline controls

### DIFF
--- a/apps/exrtool-gui/web/index.html
+++ b/apps/exrtool-gui/web/index.html
@@ -45,7 +45,7 @@
     </header>
     <main>
       <canvas id="cv"></canvas>
-      <div>
+      <div id="side-panel" style="grid-row: 1 / span 2;">
         <canvas id="hist" width="256" height="100"></canvas>
         <canvas id="waveform" width="256" height="100"></canvas>
         <div class="scope-controls">
@@ -74,6 +74,17 @@
             <thead><tr><th>Name</th><th>Value</th><th></th></tr></thead>
             <tbody></tbody>
           </table>
+        </div>
+      </div>
+      <div id="timeline-panel">
+        <input id="timeline" type="range" min="0" max="0" value="0" />
+        <div class="timeline-buttons">
+          <button id="btn-first">⏮</button>
+          <button id="btn-prev">◀</button>
+          <button id="btn-play">▶</button>
+          <button id="btn-next">▶</button>
+          <button id="btn-last">⏭</button>
+          <span id="frame-counter">0/0</span>
         </div>
       </div>
     </main>

--- a/apps/exrtool-gui/web/index.js
+++ b/apps/exrtool-gui/web/index.js
@@ -11,6 +11,10 @@
   let waveform = null;
   let scopeChannel = 'rgb';
   let scopeScale = 1;
+  let framePaths = [];
+  let currentFrame = 0;
+  let playTimer = null;
+  const PLAY_FPS = 24;
 
   // 簡易デバウンス
   function debounce(fn, ms) {
@@ -76,6 +80,105 @@
     }
     appendLog('Tauri API 解決に失敗');
     return false;
+  }
+
+  async function detectSequence(path) {
+    const m = path.match(/^(.*[\\\/])([^\\\/]*?)(\d+)(\.exr)$/i);
+    if (!m) return [path];
+    const dir = m[1];
+    const prefix = m[2];
+    const ext = m[4];
+    try {
+      if (!(await ensureTauriReady())) return [path];
+      const fs = window.__TAURI__ && window.__TAURI__.fs;
+      if (!fs || !fs.readDir) return [path];
+      const entries = await fs.readDir(dir);
+      const files = entries
+        .filter(e => !e.children && e.name && e.name.startsWith(prefix) && e.name.endsWith(ext))
+        .map(e => e.path || (dir + e.name));
+      files.sort((a,b)=>{
+        const ma = a.match(/(\d+)(\.exr)$/i);
+        const mb = b.match(/(\d+)(\.exr)$/i);
+        const na = ma ? parseInt(ma[1],10) : 0;
+        const nb = mb ? parseInt(mb[1],10) : 0;
+        return na - nb;
+      });
+      return files.length ? files : [path];
+    } catch (_) { return [path]; }
+  }
+
+  function updateTimelineUI() {
+    const tl = getEl('timeline');
+    const counter = getEl('frame-counter');
+    if (tl) {
+      tl.max = Math.max(0, framePaths.length - 1);
+      tl.value = currentFrame;
+      tl.disabled = framePaths.length <= 1;
+    }
+    if (counter) counter.textContent = `${framePaths.length ? currentFrame + 1 : 0}/${framePaths.length}`;
+  }
+
+  async function loadFrame(idx) {
+    if (idx < 0 || idx >= framePaths.length) return;
+    currentFrame = idx;
+    const path = framePaths[idx];
+    const pathEl = getEl('path');
+    const cv = getEl('cv');
+    const info = getEl('info');
+    if (!pathEl || !cv || !info) return;
+    pathEl.value = path;
+    const ctx = cv.getContext('2d');
+    const lutPath = null;
+    try {
+      if (!(await ensureTauriReady())) throw new Error('Tauri API が利用できません');
+      const [w, h, b64] = await invoke('open_exr', {
+        path,
+        maxSize: MAX_PREVIEW,
+        exposure: 0,
+        gamma: 1.0,
+        lutPath: lutPath,
+        highQuality: true
+      });
+      const img = new Image();
+      img.onload = () => {
+        imgW = w; imgH = h;
+        cv.width = w; cv.height = h;
+        ctx.clearRect(0,0,w,h);
+        ctx.drawImage(img,0,0);
+        info.textContent = `preview: ${w}x${h}`;
+        appendLog(`open ok: ${w}x${h}`);
+      };
+      img.src = 'data:image/png;base64,' + b64;
+      await loadMetadata(path);
+      await refreshScopes();
+      updateTimelineUI();
+    } catch (e) {
+      if (String(e).includes('cancelled')) {
+        appendLog('読み込みキャンセル');
+      } else {
+        appendLog('読み込み失敗: ' + e);
+        alert('読み込み失敗: ' + e);
+      }
+    }
+  }
+
+  function play() {
+    if (playTimer || framePaths.length <= 1) return;
+    playTimer = setInterval(() => {
+      if (currentFrame < framePaths.length - 1) {
+        loadFrame(currentFrame + 1);
+      } else {
+        pause();
+      }
+    }, 1000 / PLAY_FPS);
+    const btn = getEl('btn-play');
+    if (btn) btn.textContent = '⏸';
+  }
+
+  function pause() {
+    if (playTimer) { clearInterval(playTimer); playTimer = null; }
+    const btn = getEl('btn-play');
+    if (btn) btn.textContent = '▶';
   }
 
   function drawHistogram(s) {
@@ -146,48 +249,15 @@
   }
 
   async function openExr() {
+    pause();
     const pathEl = getEl('path');
-    // OCIO要素の参照は必要時のみ取得（openExr内では未使用）
-    const cv = getEl('cv');
-    const info = getEl('info');
-    if (!pathEl || !cv || !info) return;
-    const ctx = cv.getContext('2d');
-
+    if (!pathEl) return;
     const path = pathEl.value.trim();
-    const lutPath = null; // 外部LUT読込は廃止
-    try {
-      if (!(await ensureTauriReady())) throw new Error('Tauri API が利用できません');
-      const [w, h, b64] = await invoke('open_exr', {
-        path,
-        // 最大プレビュー解像度（既定）
-        maxSize: MAX_PREVIEW,
-        exposure: 0,
-        gamma: 1.0,
-        lutPath: lutPath,
-        highQuality: true
-      });
-      const img = new Image();
-      img.onload = () => {
-        imgW = w; imgH = h;
-        cv.width = w; cv.height = h;
-        ctx.clearRect(0,0,w,h);
-        ctx.drawImage(img, 0, 0);
-        info.textContent = `preview: ${w}x${h}`;
-        appendLog(`open ok: ${w}x${h}`);
-      };
-      img.src = 'data:image/png;base64,' + b64;
-      await loadMetadata(path);
-      await refreshScopes();
-    } catch (e) {
-      if (String(e).includes('cancelled')) {
-        appendLog('読み込みキャンセル');
-      } else {
-        appendLog('読み込み失敗: ' + e);
-        alert('読み込み失敗: ' + e);
-      }
-    } finally {
-      // progress UI は未配線のため no-op
-    }
+    framePaths = await detectSequence(path);
+    const idx = framePaths.indexOf(path);
+    currentFrame = idx >= 0 ? idx : 0;
+    updateTimelineUI();
+    await loadFrame(currentFrame);
   }
 
   async function loadMetadata(path) {
@@ -258,6 +328,12 @@
     const clearLutBtn = null;
     const useStateLut = null;
     const addAttrBtn = getEl('add-attr');
+    const timelineEl = getEl('timeline');
+    const btnFirst = getEl('btn-first');
+    const btnPrev = getEl('btn-prev');
+    const btnPlay = getEl('btn-play');
+    const btnNext = getEl('btn-next');
+    const btnLast = getEl('btn-last');
     const progIntervalEl = getEl('progress-interval');
     const progThreshEl = getEl('progress-threshold');
     const defaultTransformEl = getEl('default-transform');
@@ -265,6 +341,13 @@
     attrTable = getEl('attr-table');
     const scopeChannelEl = getEl('scope-channel');
     const scopeScaleEl = getEl('scope-scale');
+    updateTimelineUI();
+    if (timelineEl) timelineEl.addEventListener('input', () => { pause(); loadFrame(parseInt(timelineEl.value, 10)); });
+    if (btnFirst) btnFirst.addEventListener('click', () => { pause(); loadFrame(0); });
+    if (btnPrev) btnPrev.addEventListener('click', () => { pause(); loadFrame(Math.max(0, currentFrame - 1)); });
+    if (btnNext) btnNext.addEventListener('click', () => { pause(); loadFrame(Math.min(framePaths.length - 1, currentFrame + 1)); });
+    if (btnLast) btnLast.addEventListener('click', () => { pause(); loadFrame(framePaths.length - 1); });
+    if (btnPlay) btnPlay.addEventListener('click', () => { if (playTimer) pause(); else play(); });
 
     useStateLutEnabled = true;
     scopeChannelEl?.addEventListener('change', () => {

--- a/apps/exrtool-gui/web/style.css
+++ b/apps/exrtool-gui/web/style.css
@@ -9,3 +9,7 @@ canvas { border: 1px solid #ccc; max-width: 100%; }
 #waveform { margin-bottom: 8px; }
 .scope-controls { display:flex; gap:8px; align-items:center; margin-bottom:8px; }
 .logbox { border: 1px solid #444; padding: 6px; height: 300px; overflow: auto; background: #111; color: #9f9; font-family: ui-monospace, Menlo, Consolas, monospace; }
+#timeline-panel { grid-column: 1; display:flex; flex-direction:column; gap:4px; margin-top:8px; }
+#timeline-panel input[type="range"] { width:100%; }
+.timeline-buttons { display:flex; gap:4px; align-items:center; }
+#frame-counter { margin-left:8px; font-family: ui-monospace, Menlo, Consolas, monospace; }


### PR DESCRIPTION
## Summary
- add timeline slider, playback buttons, and frame counter to preview panel
- implement play/pause and frame navigation with unified single/sequence EXR preview logic

## Testing
- `cargo build` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c6f072835c83289e4e93b1acfa48ea